### PR TITLE
Add Flask web interface for cupidcr4wl

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The site list that cupidcr4wl utilizes for searching is updated for accuracy and
 
 cupidcr4wl **will** search and return results for platforms that host content for mature adult audiences. You are expected to use this tool in accordance with the laws and regulations in your respective jurisdiction(s). If while using cupidcr4wl you believe that you have discovered a platform hosting illegal content, you can utilize the [law enforcement reporting resources](https://github.com/OSINTI4L/cupidcr4wl/blob/main/.github/LEReportingResources.md) section to report it.
 
-## [Installation](#installation) | [Usage](#usage) | [Contributing](https://github.com/OSINTI4L/cupidcr4wl/blob/main/.github/CONTRIBUTING.md) | [Documentation](https://github.com/OSINTI4L/cupidcr4wl/wiki)
+## [Installation](#installation) | [Usage](#usage) | [Web App](#web-app) | [Contributing](https://github.com/OSINTI4L/cupidcr4wl/blob/main/.github/CONTRIBUTING.md) | [Documentation](https://github.com/OSINTI4L/cupidcr4wl/wiki)
 
 </div>
 
@@ -30,7 +30,9 @@ cupidcr4wl **will** search and return results for platforms that host content fo
 
   - ```requests```
 
-  - ```rich```
+ - ```rich```
+
+  - ```flask```
 
 ## Installation
 
@@ -117,3 +119,25 @@ To perform a search of a phone number:
 &nbsp;&nbsp;&nbsp;&nbsp;```python3 cc.py -u username --debug```
 
 &nbsp;&nbsp;&nbsp;&nbsp;(more can be read on this mode in the [documentation](https://github.com/OSINTI4L/cupidcr4wl/wiki/Usage-Options) section)
+
+## Web App
+
+cupidcr4wl now ships with an optional Flask web interface that mirrors the command line functionality in your browser.
+
+1. Install the additional dependency (if you have not already):
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Start the development server:
+
+   ```bash
+   flask --app app run
+   ```
+
+   The server listens on port 5000 by default. You can also run `python app.py` if you prefer.
+
+3. Open your browser to [http://localhost:5000](http://localhost:5000) and search by username or phone number. Multiple values can be submitted by separating them with commas.
+
+> The web interface shares the same data files (`usernames.json`, `phonenumbers.json`, and `user_agents.txt`) as the CLI version, ensuring consistent search coverage across both experiences.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,82 @@
+"""Flask application that exposes the cupidcr4wl search as a web interface."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+from flask import Flask, render_template, request
+
+from search_core import load_user_agents, load_websites, search_targets
+
+BASE_DIR = Path(__file__).resolve().parent
+USER_AGENT_FILE = BASE_DIR / "user_agents.txt"
+USERNAME_SITE_FILE = BASE_DIR / "usernames.json"
+PHONE_SITE_FILE = BASE_DIR / "phonenumbers.json"
+
+app = Flask(__name__)
+
+
+def _load_user_agents() -> List[str]:
+    if not USER_AGENT_FILE.exists():
+        raise FileNotFoundError(
+            "user_agents.txt is required to run the web application."
+        )
+    return load_user_agents(str(USER_AGENT_FILE))
+
+
+USER_AGENTS: Optional[List[str]] = None
+
+
+def get_user_agents() -> List[str]:
+    global USER_AGENTS
+    if USER_AGENTS is None:
+        USER_AGENTS = _load_user_agents()
+    return USER_AGENTS
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    errors: List[str] = []
+    results = None
+    query_text = ""
+    query_type = request.form.get("query_type", "username")
+    debug = request.form.get("debug") == "on"
+
+    if request.method == "POST":
+        query_text = request.form.get("query", "").strip()
+        if not query_text:
+            errors.append("Please enter at least one username or phone number.")
+        else:
+            targets = [part.strip() for part in query_text.split(",") if part.strip()]
+            if not targets:
+                errors.append("No valid targets were supplied after splitting on commas.")
+            else:
+                site_file = USERNAME_SITE_FILE if query_type == "username" else PHONE_SITE_FILE
+                if not site_file.exists():
+                    errors.append(f"The configuration file '{site_file.name}' is missing.")
+                else:
+                    try:
+                        websites = load_websites(str(site_file))
+                        results = search_targets(
+                            targets,
+                            user_agents=get_user_agents(),
+                            websites_by_category=websites,
+                            debug=debug,
+                        )
+                    except ValueError as exc:
+                        errors.append(str(exc))
+                    except FileNotFoundError as exc:
+                        errors.append(str(exc))
+
+    return render_template(
+        "index.html",
+        results=results,
+        errors=errors,
+        query_text=query_text,
+        query_type=query_type,
+        debug=debug,
+    )
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 rich
+Flask

--- a/search_core.py
+++ b/search_core.py
@@ -1,0 +1,184 @@
+"""Shared search logic for the cupidcr4wl command line interface and web app."""
+from __future__ import annotations
+
+import json
+import random
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+import requests
+
+
+@dataclass
+class SiteResult:
+    """Represents the outcome of checking a single site."""
+
+    name: str
+    url: Optional[str]
+    status: str
+    response_code: Optional[int] = None
+    message: Optional[str] = None
+    matched_check_texts: List[str] = field(default_factory=list)
+    matched_not_found_texts: List[str] = field(default_factory=list)
+
+
+@dataclass
+class CategoryResult:
+    """Groups site results by category for a single target."""
+
+    name: str
+    sites: List[SiteResult]
+
+
+@dataclass
+class TargetResult:
+    """Collects category results for a username or phone number."""
+
+    target: str
+    categories: List[CategoryResult]
+
+
+def load_websites(file_path: str) -> Dict[str, Dict[str, dict]]:
+    """Load website information from a JSON file and organise it by category."""
+    with open(file_path, "r", encoding="utf-8") as file:
+        data = json.load(file)
+
+    if "websites" in data:
+        raw_sites = data["websites"]
+    elif "phone_numbers" in data:
+        raw_sites = data["phone_numbers"]
+    else:
+        raise ValueError("Unrecognised JSON schema: expected 'websites' or 'phone_numbers'.")
+
+    categorised_websites: Dict[str, Dict[str, dict]] = defaultdict(dict)
+    for site_name, info in raw_sites.items():
+        category = info.get("category", "Other")
+        categorised_websites[category][site_name] = info
+    return categorised_websites
+
+
+def load_user_agents(file_path: str) -> List[str]:
+    """Load user agents from a text file."""
+    with open(file_path, "r", encoding="utf-8") as file:
+        return [line.strip() for line in file if line.strip()]
+
+
+def _check_single_site(
+    target: str,
+    site_name: str,
+    info: dict,
+    user_agents: Iterable[str],
+    *,
+    debug: bool = False,
+) -> SiteResult:
+    """Check a single site for the provided target and return a structured result."""
+    url_template: Optional[str] = info.get("url")
+    url = url_template.format(username=target) if url_template else None
+    check_texts = info.get("check_text", []) or []
+    not_found_texts = info.get("not_found_text", []) or []
+
+    if not url or not check_texts:
+        return SiteResult(
+            name=site_name,
+            url=url,
+            status="skipped",
+            message="URL or check text missing.",
+        )
+
+    headers = {"User-Agent": random.choice(list(user_agents))}
+
+    try:
+        response = requests.get(url, headers=headers, timeout=5)
+    except requests.Timeout:
+        return SiteResult(
+            name=site_name,
+            url=url,
+            status="timeout",
+            message="Timeout while checking site.",
+        )
+    except requests.RequestException as exc:
+        return SiteResult(
+            name=site_name,
+            url=url,
+            status="error",
+            message=f"Network error: {exc}",
+        )
+
+    lower_text = response.text.lower()
+    matching_check_texts = [text for text in check_texts if text.lower() in lower_text]
+    matching_not_found_texts = [text for text in not_found_texts if text.lower() in lower_text]
+
+    if response.status_code == 200:
+        if matching_check_texts:
+            status = "found"
+            message = "Account found."
+        elif matching_not_found_texts:
+            status = "not_found"
+            message = "No account found."
+        else:
+            status = "possible"
+            message = "Possible account found."
+    else:
+        status = "not_found"
+        message = "No account found."
+
+    return SiteResult(
+        name=site_name,
+        url=url,
+        status=status,
+        response_code=response.status_code,
+        message=message,
+        matched_check_texts=matching_check_texts if debug else [],
+        matched_not_found_texts=matching_not_found_texts if debug else [],
+    )
+
+
+def search_targets(
+    targets: Iterable[str],
+    *,
+    user_agents: Iterable[str],
+    websites_by_category: Dict[str, Dict[str, dict]],
+    debug: bool = False,
+) -> List[TargetResult]:
+    """Search usernames or phone numbers across the configured websites."""
+    cleaned_targets = [target.strip() for target in targets if target.strip()]
+    results: List[TargetResult] = []
+
+    for target in cleaned_targets:
+        category_results: List[CategoryResult] = []
+        for category, sites in websites_by_category.items():
+            site_results: List[SiteResult] = []
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                future_to_site = {
+                    executor.submit(
+                        _check_single_site,
+                        target,
+                        site_name,
+                        info,
+                        user_agents,
+                        debug=debug,
+                    ): site_name
+                    for site_name, info in sites.items()
+                }
+                for future in as_completed(future_to_site):
+                    site_results.append(future.result())
+
+            # Sort results alphabetically for deterministic output
+            site_results.sort(key=lambda result: result.name.lower())
+            category_results.append(CategoryResult(name=category, sites=site_results))
+
+        results.append(TargetResult(target=target, categories=category_results))
+
+    return results
+
+
+__all__ = [
+    "CategoryResult",
+    "SiteResult",
+    "TargetResult",
+    "load_user_agents",
+    "load_websites",
+    "search_targets",
+]

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,299 @@
+:root {
+    color-scheme: dark;
+    --bg: #0f0f12;
+    --card-bg: #1b1b21;
+    --accent: #ff5ba5;
+    --accent-soft: rgba(255, 91, 165, 0.12);
+    --text: #f5f5f5;
+    --muted: #8f8fa3;
+    --success: #4caf50;
+    --warning: #ff9800;
+    --error: #f44336;
+    --info: #03a9f4;
+    --shadow: rgba(0, 0, 0, 0.4);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: radial-gradient(circle at top left, rgba(255, 91, 165, 0.2), transparent 60%),
+        radial-gradient(circle at bottom right, rgba(3, 169, 244, 0.15), transparent 55%),
+        var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    padding: 2rem;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.header {
+    text-align: center;
+}
+
+.header h1 {
+    font-size: 2.75rem;
+    letter-spacing: 0.08em;
+}
+
+.tagline {
+    color: var(--muted);
+    margin-top: 0.75rem;
+}
+
+.card {
+    background: linear-gradient(145deg, rgba(27, 27, 33, 0.95), rgba(21, 21, 27, 0.85));
+    border-radius: 20px;
+    padding: 2rem;
+    box-shadow: 0 20px 35px var(--shadow);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.search-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.form-label {
+    font-weight: 600;
+}
+
+textarea {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 14px;
+    color: var(--text);
+    padding: 1rem;
+    resize: vertical;
+    min-height: 120px;
+}
+
+textarea:focus {
+    outline: 2px solid rgba(255, 91, 165, 0.4);
+}
+
+.form-options {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+}
+
+.option-group {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.option-label {
+    font-weight: 600;
+    color: var(--muted);
+}
+
+.option-group label,
+.debug-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--muted);
+}
+
+.submit-btn {
+    align-self: flex-start;
+    background: linear-gradient(135deg, var(--accent), #fd6b8f);
+    border: none;
+    border-radius: 999px;
+    color: white;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    padding: 0.85rem 2.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submit-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 24px rgba(255, 91, 165, 0.35);
+}
+
+.alert {
+    border-radius: 16px;
+    padding: 1.25rem;
+    margin-top: 1rem;
+}
+
+.alert-error {
+    background: rgba(244, 67, 54, 0.1);
+    border: 1px solid rgba(244, 67, 54, 0.4);
+}
+
+.alert h2 {
+    margin-bottom: 0.75rem;
+}
+
+.alert ul {
+    list-style: disc;
+    margin-left: 1.5rem;
+}
+
+.highlight {
+    color: var(--accent);
+}
+
+.category {
+    margin-top: 1.5rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding-top: 1.5rem;
+}
+
+.category h3 {
+    margin-bottom: 1rem;
+    color: var(--muted);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.sites {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+}
+
+.site {
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 16px;
+    border: 1px solid transparent;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-height: 180px;
+}
+
+.site-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.site-header h4 {
+    font-size: 1.05rem;
+}
+
+.status {
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.site.found {
+    border-color: rgba(76, 175, 80, 0.4);
+    background: rgba(76, 175, 80, 0.08);
+}
+
+.site.found .status {
+    background: rgba(76, 175, 80, 0.2);
+    color: var(--success);
+}
+
+.site.possible {
+    border-color: rgba(255, 152, 0, 0.4);
+    background: rgba(255, 152, 0, 0.08);
+}
+
+.site.possible .status {
+    background: rgba(255, 152, 0, 0.2);
+    color: var(--warning);
+}
+
+.site.not_found {
+    border-color: rgba(143, 143, 163, 0.35);
+    background: rgba(143, 143, 163, 0.07);
+}
+
+.site.not_found .status {
+    background: rgba(143, 143, 163, 0.2);
+    color: var(--muted);
+}
+
+.site.error,
+.site.timeout,
+.site.skipped {
+    border-color: rgba(244, 67, 54, 0.4);
+    background: rgba(244, 67, 54, 0.08);
+}
+
+.site.error .status,
+.site.timeout .status,
+.site.skipped .status {
+    background: rgba(244, 67, 54, 0.2);
+    color: var(--error);
+}
+
+.site-message {
+    color: var(--text);
+    line-height: 1.5;
+}
+
+.site-message.muted {
+    color: var(--muted);
+}
+
+.response-code {
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.debug-details {
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 12px;
+    padding: 0.75rem;
+}
+
+.debug-details summary {
+    cursor: pointer;
+    color: var(--info);
+}
+
+.debug-details ul {
+    margin-left: 1.25rem;
+    margin-top: 0.5rem;
+    line-height: 1.4;
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+    body {
+        padding: 1.5rem;
+    }
+
+    .card {
+        padding: 1.5rem;
+    }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>cupidcr4wl Web</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <main class="container">
+        <header class="header">
+            <h1>💘 cupidcr4wl Web 💘</h1>
+            <p class="tagline">Search supported platforms for usernames or phone numbers without leaving your browser.</p>
+        </header>
+
+        <section class="card">
+            <form method="post" class="search-form">
+                <label for="query" class="form-label">Usernames or phone numbers</label>
+                <textarea id="query" name="query" rows="3" placeholder="e.g. username1,username2" required>{{ query_text }}</textarea>
+
+                <div class="form-options">
+                    <div class="option-group">
+                        <span class="option-label">Search by</span>
+                        <label>
+                            <input type="radio" name="query_type" value="username" {% if query_type == 'username' %}checked{% endif %}>
+                            Username
+                        </label>
+                        <label>
+                            <input type="radio" name="query_type" value="phone" {% if query_type == 'phone' %}checked{% endif %}>
+                            Phone number
+                        </label>
+                    </div>
+                    <label class="debug-toggle">
+                        <input type="checkbox" name="debug" {% if debug %}checked{% endif %}>
+                        Include debug details
+                    </label>
+                </div>
+
+                <button type="submit" class="submit-btn">Search</button>
+            </form>
+
+            {% if errors %}
+                <div class="alert alert-error">
+                    <h2>There was a problem</h2>
+                    <ul>
+                        {% for error in errors %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            {% endif %}
+        </section>
+
+        {% if results %}
+            {% for result in results %}
+                <section class="card">
+                    <h2>Results for <span class="highlight">{{ result.target }}</span></h2>
+                    {% for category in result.categories %}
+                        <div class="category">
+                            <h3>{{ category.name }}</h3>
+                            <div class="sites">
+                                {% for site in category.sites %}
+                                    <article class="site {{ site.status }}">
+                                        <header class="site-header">
+                                            <h4>{{ site.name }}</h4>
+                                            <span class="status">{{ site.status.replace('_', ' ') }}</span>
+                                        </header>
+                                        {% if site.status in ['error', 'timeout', 'skipped'] %}
+                                            <p class="site-message muted">{{ site.message }}</p>
+                                        {% else %}
+                                            <p class="site-message">{{ site.message }}</p>
+                                        {% endif %}
+                                        {% if site.url %}
+                                            <p><a href="{{ site.url }}" target="_blank" rel="noopener">Visit profile</a></p>
+                                        {% endif %}
+                                        {% if debug and (site.matched_check_texts or site.matched_not_found_texts) %}
+                                            <details class="debug-details">
+                                                <summary>Debug details</summary>
+                                                {% if site.matched_check_texts %}
+                                                    <p><strong>Matched check text:</strong></p>
+                                                    <ul>
+                                                        {% for text in site.matched_check_texts %}
+                                                            <li>{{ text }}</li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                {% endif %}
+                                                {% if site.matched_not_found_texts %}
+                                                    <p><strong>Matched not found text:</strong></p>
+                                                    <ul>
+                                                        {% for text in site.matched_not_found_texts %}
+                                                            <li>{{ text }}</li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                {% endif %}
+                                            </details>
+                                        {% endif %}
+                                        {% if site.response_code %}
+                                            <p class="response-code">HTTP {{ site.response_code }}</p>
+                                        {% endif %}
+                                    </article>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endfor %}
+                </section>
+            {% endfor %}
+        {% elif results is not none %}
+            <section class="card">
+                <p>No results were produced for this search.</p>
+            </section>
+        {% endif %}
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a reusable `search_core` module that returns structured search results for usernames and phone numbers
- build a Flask web application with templates and styling so searches can run from a browser
- document the new web experience and include Flask in the Python requirements

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68db19a690b4832f99146caf5fceeada