### PR TITLE
Add CLI version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,30 +55,32 @@ cupidcr4wl **will** search and return results for platforms that host content fo
 
 ```
 usage: cc.py [-h] [-p PHONENUMBER] [-u USERNAME] [--export-results] [--debug]
-             [--username-sites] [--phone-number-sites]
+            [--username-sites] [--phone-number-sites]
 
 A tool for checking if a username or phone number exists across various adult content
 platforms.
 
 options:
   -h, --help            show this help message and exit
-                        
+
   -p PHONENUMBER        Enter a phone number or multiple phone numbers (separated by commas)
                         to search.
-                        
+
   -u USERNAME           Enter a username or multiple usernames (separated by commas) to
                         search.
-                        
+
   --export-results      Search results will be exported to an HTML file named
                         'cc_results.html' in the current working directory.
-                        
+
   --debug               Debug mode shows all results, HTTP response codes,
                         check_text/not_found_text matches, timeouts, and errors for each
                         site checked.
-                        
+
   --username-sites      Prints all sites that cupidcr4wl will search by username.
-                        
+
   --phone-number-sites  Prints all sites that cupidcr4wl will search by phone number.
+
+  --version             Show the cupidcr4wl version number and exit.
 ```
 2) To perform a search of a username:
 
@@ -112,7 +114,11 @@ To perform a search of a phone number:
 
 &nbsp;&nbsp;&nbsp;&nbsp;```python3 cc.py --phone-number-sites```
 
-8) To run cupidcr4wl in debug mode to test for false positives/negatives and display timeouts/errors add the ```--debug``` argument:
+8) To display the current cupidcr4wl version number:
+
+&nbsp;&nbsp;&nbsp;&nbsp;```python3 cc.py --version```
+
+9) To run cupidcr4wl in debug mode to test for false positives/negatives and display timeouts/errors add the ```--debug``` argument:
 
 &nbsp;&nbsp;&nbsp;&nbsp;```python3 cc.py -u username --debug```
 

--- a/cc.py
+++ b/cc.py
@@ -10,6 +10,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 console = Console()
 
+__version__ = "2.1"
+
 ASCII_ART = r"""
           [bold cyan]_
       [bold magenta].-'` |___________________________//////
@@ -316,6 +318,13 @@ def parse_arguments():
         help="Prints all sites that cupidcr4wl will search by phone number."
     )
 
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"cupidcr4wl {__version__}",
+        help="Show the cupidcr4wl version number and exit."
+    )
+
     return parser.parse_args()
 
 
@@ -324,8 +333,8 @@ def parse_arguments():
 
 def main():
     """Main entry point for the script."""
-    display_ascii_art()  # Show ASCII art
     args = parse_arguments()  # Parse command-line arguments
+    display_ascii_art()  # Show ASCII art
 
     # Check if no arguments are provided
     if not (args.u or args.p or args.username_sites or args.phone_number_sites or args.export_results):


### PR DESCRIPTION
## Summary
- add a reusable `__version__` constant and expose it via a new `--version` CLI option
- parse arguments before rendering ASCII art so help/version requests exit cleanly
- document the new option in the README usage section

## Testing
- python3 cc.py --version

------
https://chatgpt.com/codex/tasks/task_e_68db196e1938832faae7a95a4854d1eb